### PR TITLE
Add Mac compatibility

### DIFF
--- a/Source/IM4U/Classes/Factory/VmdImportOption.h
+++ b/Source/IM4U/Classes/Factory/VmdImportOption.h
@@ -5,7 +5,7 @@
 #include "CoreMinimal.h"
 
 #include "MainFrame.h"
-#include "Modules\ModuleManager.h"
+#include "Modules/ModuleManager.h"
 //#include "DirectoryWatcherModule.h"
 //#include "../../../DataTableEditor/Public/IDataTableEditor.h"
 #include "Engine/UserDefinedStruct.h"

--- a/Source/IM4U/IM4U.Build.cs
+++ b/Source/IM4U/IM4U.Build.cs
@@ -64,6 +64,10 @@ namespace UnrealBuildTool.Rules
 				PublicAdditionalLibraries.Add(Path.Combine(LibraryPath, LibName + ".lib"));
 
 			}
+			else if (Target.Platform == UnrealTargetPlatform.Mac)
+			{
+				PublicAdditionalLibraries.Add("/usr/lib/libiconv.dylib");
+			}
 			
 			
 			PublicIncludePaths.AddRange(

--- a/Source/IM4U/Private/EncodeHelper.cpp
+++ b/Source/IM4U/Private/EncodeHelper.cpp
@@ -33,7 +33,7 @@ std::string EncodeHelper::convert_encoding(const std::string &str, const char *f
 		else if (err == EILSEQ) {
 			errstr = "An invalid multibyte sequence has been encountered in the input";
 		}
-		else if (err = EINVAL) {
+		else if (err == EINVAL) {
 			errstr = "An incomplete multibyte sequence has been encountered in the input";
 		}
 		iconv_close(icd);

--- a/Source/IM4U/Private/PmxFactory.cpp
+++ b/Source/IM4U/Private/PmxFactory.cpp
@@ -220,7 +220,7 @@ UObject* UPmxFactory::FactoryCreateBinary
 	if (!pmxImportResult)
 	{
 		// Log the error message and fail the import.
-		Warn->Log(ELogVerbosity::Error, L"PMX Import ERR...FLT");
+		Warn->Log(ELogVerbosity::Error, "PMX Import ERR...FLT");
 		FEditorDelegates::OnAssetPostImport.Broadcast(this, NULL);
 		return NULL;
 	}
@@ -606,7 +606,7 @@ UObject* UPmxFactory::FactoryCreateBinary
 		if (NewObject == NULL)
 		{
 			AddTokenizedErrorMessage(FTokenizedMessage::Create(EMessageSeverity::Error, LOCTEXT("FailedToImport_NoObject", "Import failed.")), FFbxErrors::Generic_ImportingNewObjectFailed);
-			Warn->Log(ELogVerbosity::Error, L"PMX Import ERR [NewObject is NULL]...FLT");
+			Warn->Log(ELogVerbosity::Error, "PMX Import ERR [NewObject is NULL]...FLT");
 		}
 
 		//FbxImporter->ReleaseScene();


### PR DESCRIPTION
By this change, mac can compile IM4U plugin.

**Tested environment**
- macOS 10.15.5
- Unreal Engine 4.25.1
- Xcode 11.5

**Screenshot**
- The model is downloaded from https://3d.nicovideo.jp/works/td63645
© 2019 cover corp.

<img width="460" alt="Screen Shot 2020-06-13 at 19 40 32" src="https://user-images.githubusercontent.com/1047810/84566778-c8066b00-adae-11ea-9891-b4fc7528fa4a.png">